### PR TITLE
fix: Whitespace & indentation issues in `Fragment` & `Root` nodes

### DIFF
--- a/packages/svelte-ast-print/src/_internal/js.ts
+++ b/packages/svelte-ast-print/src/_internal/js.ts
@@ -9,13 +9,14 @@ import type { Options } from "./option.ts";
  * TODO: Align with `esrap`, if it evers become pluggable
  * Ref: https://github.com/sveltejs/esrap/issues/35
  */
-export function print_js(n: JS.Node, opts: Options): string {
+export function print_js(n: JS.Node, opts: Options, svelte = true): string {
+	const { code } = esrap.print(n, { indent: opts.indent });
+	if (!svelte) return code;
 	return (
-		esrap
-			.print(n, { indent: opts.indent })
-			.code.split(char.NL)
+		code
+			.split(char.NL)
 			.map((ln, idx) => {
-				// NOTE: it removes empty lines, except for the first one
+				// // NOTE: it prevents the first line or empty line from having indentation
 				if (!idx || !ln) return ln;
 				return `${opts.indent}${ln}`;
 			})

--- a/packages/svelte-ast-print/src/_internal/shared.ts
+++ b/packages/svelte-ast-print/src/_internal/shared.ts
@@ -197,13 +197,22 @@ class Collector {
 }
 
 /**
- * @internal
+ * Instance with the result of printing _(serializing)_ AST {@link Node}.
  */
 export class Result<N extends Node = Node> {
 	node: N;
+	/**
+	 * @internal
+	 */
 	opts: Options;
+	/**
+	 * @internal
+	 */
 	collector: Collector;
 
+	/**
+	 * @internal
+	 */
 	constructor(node: N, opts: Options, collector: Collector) {
 		this.node = node;
 		this.opts = opts;
@@ -250,6 +259,9 @@ export class Result<N extends Node = Node> {
 
 	#cached = false;
 
+	/**
+	 * @internal
+	 */
 	get lines(): Line[] {
 		if (this.#cached) return this.#lines;
 		this.#cached = true;
@@ -258,6 +270,9 @@ export class Result<N extends Node = Node> {
 		return this.#lines;
 	}
 
+	/**
+	 * Get the stringified output.
+	 */
 	get code(): string {
 		return this.lines.map((ln) => ln.toString(this.opts.indent)).join(char.NL);
 	}

--- a/packages/svelte-ast-print/src/lib.ts
+++ b/packages/svelte-ast-print/src/lib.ts
@@ -96,7 +96,7 @@ export function print<N extends Node>(n: N, opts: Partial<PrintOptions> = {}): R
 	if (isSvelteOnlyNode(n)) return printSvelte(n, opts) as Result<N>;
 	else {
 		const st = State.get(n, opts);
-		st.add(print_js(n, st.opts));
+		st.add(print_js(n, st.opts, false));
 		return st.result as Result<N>;
 	}
 }

--- a/packages/svelte-ast-print/src/template/root.ts
+++ b/packages/svelte-ast-print/src/template/root.ts
@@ -21,37 +21,50 @@ import { printSvelteOptions } from "./element-like.ts";
  */
 export function printRoot(n: SV.Root, opts: Partial<PrintOptions> = {}): Result<SV.Root> {
 	const st = State.get(n, opts);
+	let had_previous_node = false;
+	const insert_two_line_breaks = () => {
+		st.break();
+		st.break();
+	};
 	for (const [idx, curr_name] of st.opts.order.entries()) {
 		switch (curr_name) {
 			case "options": {
-				if (n.options) st.add(printSvelteOptions(n.options, opts));
+				if (n.options) {
+					if (had_previous_node) insert_two_line_breaks();
+					st.add(printSvelteOptions(n.options, opts));
+				}
 				break;
 			}
 			case "instance": {
-				if (n.instance) st.add(printScript(n.instance, opts));
+				if (n.instance) {
+					if (had_previous_node) insert_two_line_breaks();
+					st.add(printScript(n.instance, opts));
+				}
 				break;
 			}
 			case "module": {
-				if (n.module) st.add(printScript(n.module, opts));
+				if (n.module) {
+					if (had_previous_node) insert_two_line_breaks();
+					st.add(printScript(n.module, opts));
+				}
 				break;
 			}
 			case "fragment": {
-				st.add(printFragment(n.fragment, opts));
+				if (n.fragment.nodes.length) {
+					if (had_previous_node) insert_two_line_breaks();
+					st.add(printFragment(n.fragment, opts));
+				}
 				break;
 			}
 			case "css": {
-				if (n.css) st.add(printCSSStyleSheet(n.css, opts));
+				if (n.css) {
+					if (had_previous_node) insert_two_line_breaks();
+					st.add(printCSSStyleSheet(n.css, opts));
+				}
 				break;
 			}
 		}
-		const is_last = st.opts.order.at(-1) === curr_name;
-		const prev_name = st.opts.order[idx - 1];
-		const next_name = st.opts.order[idx + 1];
-		// NOTE: This adds line break (x2) between each part of the root
-		if (!is_last && (n[curr_name] || (prev_name && n[prev_name])) && next_name && n[next_name]) {
-			st.break();
-			st.break();
-		}
+		if (idx && n[curr_name]) had_previous_node = true;
 	}
 	return st.result;
 }


### PR DESCRIPTION
Found some issues while locally testing `@storybook/addon-svelte-csf`, this PR aims to fix them.
